### PR TITLE
Fix redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.4'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation "org.testcontainers:postgresql:1.20.6"
-    testImplementation 'com.redis.testcontainers:testcontainers-redis:1.6.4'
+    testImplementation 'com.redis:testcontainers-redis:2.2.4'
     testImplementation 'org.mockito:mockito-core:5.16.1'
     mockitoAgent 'org.mockito:mockito-core:5.16.1'
     // Support tools

--- a/src/main/java/com/biezbardis/thoughtyusers/configuration/RedisConfig.java
+++ b/src/main/java/com/biezbardis/thoughtyusers/configuration/RedisConfig.java
@@ -1,24 +1,37 @@
 package com.biezbardis.thoughtyusers.configuration;
 
+import com.biezbardis.thoughtyusers.entity.RefreshToken;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import java.time.Duration;
+import java.util.UUID;
 
 @Configuration
 @EnableCaching
 public class RedisConfig {
-    private static final Duration TTL = Duration.ofDays(7); // Cache expiration time
 
     @Bean
-    public RedisCacheConfiguration cacheConfiguration() {
-        return RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(TTL)
-                .disableCachingNullValues()
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+    public RedisConnectionFactory redisConnectionFactory(RedisProperties redisProperties) {
+        var connectionFactory = new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+        connectionFactory.afterPropertiesSet();
+        return connectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<UUID, RefreshToken> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<UUID, RefreshToken> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
     }
 }

--- a/src/main/java/com/biezbardis/thoughtyusers/configuration/RedisConfig.java
+++ b/src/main/java/com/biezbardis/thoughtyusers/configuration/RedisConfig.java
@@ -9,7 +9,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.util.UUID;
 
@@ -19,9 +18,7 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory(RedisProperties redisProperties) {
-        var connectionFactory = new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
-        connectionFactory.afterPropertiesSet();
-        return connectionFactory;
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
     }
 
     @Bean
@@ -29,7 +26,7 @@ public class RedisConfig {
         RedisTemplate<UUID, RefreshToken> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
 
-        template.setKeySerializer(new StringRedisSerializer());
+        template.setKeySerializer(new GenericJackson2JsonRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return template;

--- a/src/main/java/com/biezbardis/thoughtyusers/configuration/RedisConfig.java
+++ b/src/main/java/com/biezbardis/thoughtyusers/configuration/RedisConfig.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.util.UUID;
 
@@ -26,7 +27,7 @@ public class RedisConfig {
         RedisTemplate<UUID, RefreshToken> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
 
-        template.setKeySerializer(new GenericJackson2JsonRedisSerializer());
+        template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return template;

--- a/src/main/java/com/biezbardis/thoughtyusers/entity/RefreshToken.java
+++ b/src/main/java/com/biezbardis/thoughtyusers/entity/RefreshToken.java
@@ -1,7 +1,5 @@
 package com.biezbardis.thoughtyusers.entity;
 
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,7 +20,6 @@ import java.util.UUID;
 @RedisHash(value = "refresh_tokens", timeToLive = 60 * 60 * 24 * 7) // TTL = 7 days
 public class RefreshToken implements Serializable {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
     private String username;

--- a/src/main/java/com/biezbardis/thoughtyusers/entity/RefreshToken.java
+++ b/src/main/java/com/biezbardis/thoughtyusers/entity/RefreshToken.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.redis.core.RedisHash;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.UUID;
 
@@ -18,8 +19,8 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@RedisHash("refresh_tokens")
-public class RefreshToken {
+@RedisHash(value = "refresh_tokens", timeToLive = 60 * 60 * 24 * 7) // TTL = 7 days
+public class RefreshToken implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,12 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      timeout: 5000
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 5
+
   lifecycle:
     timeout-per-shutdown-phase: 5s
 

--- a/src/test/java/com/biezbardis/thoughtyusers/ThoughtyUsersApplicationTests.java
+++ b/src/test/java/com/biezbardis/thoughtyusers/ThoughtyUsersApplicationTests.java
@@ -167,7 +167,7 @@ public class ThoughtyUsersApplicationTests {
                 .findFirst()
                 .orElse(null);
 
-        Thread.sleep(2000);
+        Thread.sleep(5000);
 
         json = String.format("""
                 {

--- a/src/test/java/com/biezbardis/thoughtyusers/ThoughtyUsersApplicationTests.java
+++ b/src/test/java/com/biezbardis/thoughtyusers/ThoughtyUsersApplicationTests.java
@@ -83,7 +83,7 @@ public class ThoughtyUsersApplicationTests {
 
         // RedisContainer
         registry.add("spring.data.redis.host", redis::getHost);
-        registry.add("spring.data.redis.port", () -> redis.getFirstMappedPort().toString());
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
     }
 
     @Test
@@ -167,6 +167,7 @@ public class ThoughtyUsersApplicationTests {
                 .findFirst()
                 .orElse(null);
 
+        Thread.sleep(2000);
 
         json = String.format("""
                 {


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored Redis configuration to use LettuceConnectionFactory and RedisTemplate.

- Added TTL and serialization to RefreshToken entity for Redis.

- Improved Redis test container property handling in integration tests.

- Enhanced Redis connection pool and timeout settings in application config.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RedisConfig.java</strong><dd><code>Refactor Redis configuration with Lettuce and RedisTemplate</code></dd></summary>
<hr>

src/main/java/com/biezbardis/thoughtyusers/configuration/RedisConfig.java

<li>Switched to LettuceConnectionFactory for Redis connections.<br> <li> Introduced RedisTemplate with custom serializers.<br> <li> Removed old RedisCacheConfiguration setup.


</details>


  </td>
  <td><a href="https://github.com/OffhandForge/thoughty-users/pull/15/files#diff-83fe070b1470c57588602183bde16e45db0fa93f844958a39cd7d55bd3b5de15">+22/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RefreshToken.java</strong><dd><code>Add TTL and serialization to RefreshToken entity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/biezbardis/thoughtyusers/entity/RefreshToken.java

<li>Made RefreshToken implement Serializable.<br> <li> Set RedisHash TTL to 7 days directly on entity.<br> <li> Updated RedisHash annotation for TTL support.


</details>


  </td>
  <td><a href="https://github.com/OffhandForge/thoughty-users/pull/15/files#diff-2e1dbc356859e71d2cd7edb393507a5165cee16057e2c3452411be97c1daf132">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ThoughtyUsersApplicationTests.java</strong><dd><code>Improve Redis test container property and timing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/biezbardis/thoughtyusers/ThoughtyUsersApplicationTests.java

<li>Fixed Redis port property to use integer instead of string.<br> <li> Added sleep before token refresh test for timing reliability.


</details>


  </td>
  <td><a href="https://github.com/OffhandForge/thoughty-users/pull/15/files#diff-0d4d46c2b39b64e2f1d7d3c54a2931ae474fd45b27adae64f09fb0fe9f739ee1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>application.yml</strong><dd><code>Enhance Redis connection and pool settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/application.yml

<li>Added Redis timeout and Lettuce pool configuration.<br> <li> Improved Redis connection settings for performance.


</details>


  </td>
  <td><a href="https://github.com/OffhandForge/thoughty-users/pull/15/files#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>